### PR TITLE
Throw out bad samples

### DIFF
--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -10,8 +10,8 @@ task make_mask_and_diff {
 		File vcf
 		File? tbmf
 		Int min_coverage_per_site
-		Boolean diffs = true
 		Boolean histograms = false
+		Float discard_sample_if_
 
 		# runtime attributes
 		Int addldisk = 10
@@ -58,17 +58,17 @@ task make_mask_and_diff {
 		bedtools genomecov -ibam sorted_u_~{basename_bam}.bam > histogram.txt
 	fi
 	
-	if [[ "~{diffs}" = "true" ]]
-	then
-		echo "Pulling script..."
-		wget https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.8/vcf_to_diff_script.py
-		echo "Running script..."
-		python3 vcf_to_diff_script.py -v ~{vcf} \
-		-d . \
-		-tbmf ${mask} \
-		-bed ~{basename_bam}_below_~{min_coverage_per_site}x_coverage.bedgraph \
-		-cd ~{min_coverage_per_site}
-	fi
+	echo "Pulling diff script..."
+	wget https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.8/vcf_to_diff_script.py
+	echo "Running script..."
+	python3 vcf_to_diff_script.py -v ~{vcf} \
+	-d . \
+	-tbmf ${mask} \
+	-bed ~{basename_bam}_below_~{min_coverage_per_site}x_coverage.bedgraph \
+	-cd ~{min_coverage_per_site}
+	
+	
+	
 	end=$(date +%s)
 	seconds=$(echo "$end - $start" | bc)
 	minutes=$(echo "$seconds" / 60 | bc)


### PR DESCRIPTION
This PR allows the filtering out of samples in `make_mask_and_diff` that have too many low coverage sites to happen in the diff-making task, rather than passing the buck to downstream tasks. This is more in line with behavior of other filtering tasks in myco.

As before, sites are considered low coverage if they are below `min_coverage_per_site`x coverage, and a report file is created that keeps track of how much of the sample gets masked for being below that coverage. What changed is that the user can now throw out the sample immediately, returning an "error" message, based on that report file. The cutoff is set by `max_ratio_low_coverage_sites_per_sample`. 

Input changes
* `diffs` is removed -- now diff files will always be created (but may not be output) 
* added `max_ratio_low_coverage_sites_per_sample` as explained above
* added `force_diffs`, which will force the output of diffs the sample gets thrown out for having too many low coverage sites 
* added a parameter meta section

Other
* That old `make_diff` task is now named `make_diff_legacy`