### PR TITLE
Mark unclustered samples

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+# clean workdir after distancematrix_nwk.py
+rm maxtree*
+rm n_clusters n_samples_in_clusters total_samples_processed

--- a/distancematrix_nwk.py
+++ b/distancematrix_nwk.py
@@ -166,9 +166,10 @@ if not args.nocluster:
         # build per_sample_cluster lines for this cluster - this will be used for auspice annotation
         for sample in clusters[i]:
             per_sample_cluster.append(f"{sample}\tcluster{i}\n")
-        for sample in lonely:
-            per_sample_cluster.append(f"{sample}\tlonely\n")
     
+    # add in the unclustered samples (outside for loop to avoid writing multiple times)
+    for sample in lonely:
+            per_sample_cluster.append(f"{sample}\tlonely\n")
     per_cluster_samples.append("\n") # to avoid skipping last line when read
 
     # generate an auspice-style TSV for annotation of clusters

--- a/distancematrix_nwk.py
+++ b/distancematrix_nwk.py
@@ -12,7 +12,7 @@ parser.add_argument('-s', '--samples', required=False, type=str,help='comma sepa
 parser.add_argument('-v', '--verbose', action='store_true', help='enable debug logging')
 parser.add_argument('-nc', '--nocluster', action='store_true', help='do not search for clusters')
 parser.add_argument('-o', '--out', required=False, type=str, help='what to append to output file name')
-parser.add_argument('-d', '--distance', default=50, type=int, help='max distance between samples to identify as clustered')
+parser.add_argument('-d', '--distance', default=20, type=int, help='max distance between samples to identify as clustered')
 
 args = parser.parse_args()
 logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
@@ -93,7 +93,7 @@ def dist_matrix(tree, samples):
                     matrix[j][i] = total_distance
                     if not args.nocluster:
                         if total_distance <= args.distance:
-                            logging.info(f"  {s} and {os} might be in a cluster ({total_distance})")
+                            logging.debug(f"  {s} and {os} might be in a cluster ({total_distance})")
                             neighbors.append(tuple((s, os)))
                             definitely_in_a_cluster = True
         # after iterating through all of j, if this sample is not in a cluster, make note of that
@@ -105,7 +105,7 @@ def dist_matrix(tree, samples):
                 if second_smallest_distance <= args.distance:
                     logging.debug(f"  Oops, {s} was already clustered! (closest sample is {second_smallest_distance}) SNPs away")
                 else:
-                    logging.info(f"  {s} appears to be truly unclustered (closest sample is {second_smallest_distance} SNPs away)")
+                    logging.debug(f"  {s} appears to be truly unclustered (closest sample is {second_smallest_distance} SNPs away)")
                     unclustered.add(s)
     if not args.nocluster:
         true_clusters = []

--- a/distancematrix_nwk.py
+++ b/distancematrix_nwk.py
@@ -34,7 +34,7 @@ def path_to_root(ete_tree, node):
     while node:
         node = node.up
         path.append(node)
-    logging.debug(f"path for {node}: {path}")
+    #logging.debug(f"path for {node}: {path}")
     return path
 
 
@@ -54,7 +54,8 @@ def dist_matrix(tree, samples):
 
     for i in progressbar.trange(len(samples), desc="Creating matrix"): # trange is a tqdm optimized version of range
         s = samples[i]
-        in_a_cluster = False
+        definitely_in_a_cluster = False
+        logging.debug(f"Checking {s}")
 
         for j in range(len(samples)):
             os = samples[j]
@@ -76,30 +77,36 @@ def dist_matrix(tree, samples):
                         
                             lca = a
                             s_path -= a.dist
-                            #logging.debug(f"found a in samp_ancs[os], setting s_path")
+                            #logging.debug(f"  found a in samp_ancs[os], setting s_path")
                             break
                     
                     for a in samp_ancs[os]:
                         
                         os_path += a.dist
                         if a == lca:
-                            #logging.debug(f'a == lca, setting os_path')
+                            #logging.debug(f'  a == lca, setting os_path')
                             os_path -= a.dist
                             break
-                    logging.debug(f"sample {s} vs other sample {os}:")
-                    logging.debug(f"s_path {s_path}, os_path {os_path}")
+                    logging.debug(f"  sample {s} vs other sample {os}: s_path {s_path}, os_path {os_path}")
                     total_distance = int(s_path + os_path)
                     matrix[i][j] = total_distance
                     matrix[j][i] = total_distance
                     if not args.nocluster:
                         if total_distance <= args.distance:
-                            logging.debug(f"{s} and {os} might be in a cluster ({total_distance})")
+                            logging.debug(f"  {s} and {os} might be in a cluster ({total_distance})")
                             neighbors.append(tuple((s, os)))
-                            in_a_cluster = True
+                            definitely_in_a_cluster = True
         # after iterating through all of j, if this sample is not in a cluster, make note of that
         if not args.nocluster:
-            if not in_a_cluster:
-                unclustered.add(s)
+            if not definitely_in_a_cluster:
+                logging.debug(f"  {s} is either not in a cluster or clustered early")
+                logging.debug(matrix[i])
+                second_smallest_distance = np.partition(matrix[i], 1)[1] # second smallest, because smallest is self-self at 0
+                if second_smallest_distance <= args.distance:
+                    logging.debug(f"  Oops, {s} was already clustered! (closest sample is {second_smallest_distance}) SNPs away")
+                else:
+                    logging.debug(f"  {s} appears to be truly unclustered (closest sample is {second_smallest_distance} SNPs away)")
+                    unclustered.add(s)
     if not args.nocluster:
         true_clusters = []
         first_iter = True
@@ -137,15 +144,15 @@ total_samples_processed = len(samps)
 # this could probably be made more efficient
 if not args.nocluster:
 
-    # per_sample_cluster is the Nextstrain-style TSV used for annotation, eg:
+    # sample_cluster is the Nextstrain-style TSV used for annotation, eg:
     # sample12    cluster1
     # sample13    cluster1
     # sample14    cluster1
-    per_sample_cluster = ['Sample\tCluster\n']
+    sample_cluster = ['Sample\tCluster\n']
 
-    # per_cluster_samples is for matutils extract to generate Nextstrain subtrees, eg:
+    # cluster_samples is for matutils extract to generate Nextstrain subtrees, eg:
     # cluster1    sample12,sample13,sample14
-    per_cluster_samples = ['Cluster\tSamples\n']
+    cluster_samples = ['Cluster\tSamples\n']
 
     # summary information for humans to look at
     n_clusters = len(clusters) # immutable
@@ -157,28 +164,31 @@ if not args.nocluster:
         n_samples_in_clusters += len(samples_in_cluster)
         samples_in_cluster_str = ",".join(samples_in_cluster)
 
-        # build per_cluster_samples line for this cluster
-        per_cluster_samples.append(f"cluster{i}\t{samples_in_cluster_str}\n")
+        # build cluster_samples line for this cluster
+        cluster_samples.append(f"cluster{i}\t{samples_in_cluster_str}\n")
 
         # recurse to matrix each cluster
         os.system(f"python3 distancematrix_nwk.py -s{samples_in_cluster_str} -nc -o {prefix}_cluster{i} '{tree}'")
         
-        # build per_sample_cluster lines for this cluster - this will be used for auspice annotation
+        # build sample_cluster lines for this cluster - this will be used for auspice annotation
         for sample in clusters[i]:
-            per_sample_cluster.append(f"{sample}\tcluster{i}\n")
+            sample_cluster.append(f"{sample}\tcluster{i}\n")
     
     # add in the unclustered samples (outside for loop to avoid writing multiple times)
     for sample in lonely:
-            per_sample_cluster.append(f"{sample}\tlonely\n")
-    per_cluster_samples.append("\n") # to avoid skipping last line when read
+        sample_cluster.append(f"{sample}\tlonely\n")
+    unclustered_as_str = ','.join(lonely)
+    cluster_samples.append(f"lonely\t{unclustered_as_str}\n")
+    cluster_samples.append("\n") # to avoid skipping last line when read
+    os.system(f"python3 distancematrix_nwk.py -s{unclustered_as_str} -nc -o {prefix}_lonely '{tree}'")
 
     # generate an auspice-style TSV for annotation of clusters
     with open(f"{prefix}_cluster_annotation.tsv", "a") as samples_for_annotation:
-        samples_for_annotation.writelines(per_sample_cluster)
+        samples_for_annotation.writelines(sample_cluster)
     
     # generate another TSV for subtree annotation
     with open(f"{prefix}_cluster_extraction.tsv", "a") as clusters_for_subtrees:
-        clusters_for_subtrees.writelines(per_cluster_samples)
+        clusters_for_subtrees.writelines(cluster_samples)
     
     # generate little summary files for WDL to parse directly
     with open("n_clusters", "w") as n_cluster: n_cluster.write(str(n_clusters))


### PR DESCRIPTION
* Unclustered samples are now given their own tree annotations and distance matrix
* Small logging improvements 
* Distance defaults to 20, same as the WDL
* Clearer internal variable names
* Distance matrices are now alphabetized... somehow (checked several samples by hand, this is working correctly and not messing up the matrix)

This has been tested a lot and is ready to rumble.